### PR TITLE
[#1460] add TLSv1.2 with SSL validation for client

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,6 @@ repository.mongodb options :
 | sslEnabled 		                               |            |
 | threadsAllowedToBlockForConnectionMultiplier     |            |
 | cursorFinalizerEnabled                           |            |
+| keystorePassword                                 |            |
+| keystore                                         |            |
+| keyPassword                                      |            |


### PR DESCRIPTION
Add to the existing SSL simple mode for encrypted communication the ability to trust client against Man of the middle attack with client certificate validation (production recommended strategy by Mongodb official doc)
Be careful to generate trusted certificate with Server and client extension to configure mongodb replicaSet. Mongodb node sync is also encrypted and double authenticated.
For gravitee api and gateway client is enough.
CACERT of the jre running the gateway must trust CA of the mongodb replicaSet (and same way for the replicaset that must trust gravitee)

sample conf :
`
management:
  type: mongodb
  mongodb:
    dbname: gravitee
    authSource: gravitee
    servers:
      - host: mongodb1
        port: 27017
      - host: mongodb2
        port: 27017
      - host: mongodb3
        port: 27017
    username: foo
    password: foo
    sslEnabled: True
    keystorePassword: changeit
    keystore: /opt/gravitee-io-gateway/ssl/mongodb.jks
    keyPassword: changeit

`