### PR TITLE
Add WriteConcern capabilities to Gravitee mongodb repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ repository.mongodb options :
 | password                                         |            |
 | connectionPerHost                                |            |
 | connectTimeout                                   |            |
+| writeConcern                                     |      1     |
+| wtimeout                                         |    0       |
+| journal                                          |            |
 | maxWaitTime                                      |            |
 | socketTimeout                                    |            |
 | socketKeepAlive                                  |            |
@@ -59,3 +62,5 @@ repository.mongodb options :
 | keystorePassword                                 |            |
 | keystore                                         |            |
 | keyPassword                                      |            |
+
+NB: writeConcern possible value are 1,2,3... (the number of node) or 'majority' 


### PR DESCRIPTION
This closes gravitee-io/issues#2177

I chose to rely on https://docs.mongodb.com/manual/reference/write-concern/ and give to gravitee users several writeconcern mode : 

New properties : 
* writeConcern : default to 1 
* wtimeout : default to 0 
* journal: default to null as official mongodb doc describes it